### PR TITLE
fix oDia to oDIA_Choice

### DIFF
--- a/Code/AltSearch/Local_cs.xba
+++ b/Code/AltSearch/Local_cs.xba
@@ -253,7 +253,7 @@ Sub Load_cs
 	end with
 
 	&apos; dialog D_choice
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label       =&quot;Jméno skriptu&quot;
 		.Bt_app.HelpText =&quot;Připojí současné parametry hledáné na konec existující dávky&quot;
 		.Bt_app.Label    =&quot;Připojit na konec&quot;

--- a/Code/AltSearch/Local_de.xba
+++ b/Code/AltSearch/Local_de.xba
@@ -252,7 +252,7 @@ Sub Load_de
 	end with
 
 	&apos; dialog choice
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label       =&quot;Name der Batch&quot;
 		.Bt_app.HelpText =&quot;Parameter am Ende einer existierenden Batch hinzufügen&quot;
 		.Bt_app.Label    =&quot;Hinzufügen&quot;

--- a/Code/AltSearch/Local_en.xba
+++ b/Code/AltSearch/Local_en.xba
@@ -254,7 +254,7 @@ Sub Load_en
 	end with
 
 	&apos; dialog choice
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label       =&quot;Name of batch&quot;
 		.Bt_app.HelpText =&quot;Append current parameters to end of existing batch&quot;
 		.Bt_app.Label    =&quot;Append&quot;

--- a/Code/AltSearch/Local_es.xba
+++ b/Code/AltSearch/Local_es.xba
@@ -253,7 +253,7 @@ Sub Load_es
 	end with
 
 	&apos; dialog choice
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label           = &quot;Nombre del lote&quot;
 		.Bt_app.HelpText     = &quot;Añadir parámetros actuales al final de lote existente&quot;
 		.Bt_app.Label        = &quot;Añadir&quot;

--- a/Code/AltSearch/Local_fr.xba
+++ b/Code/AltSearch/Local_fr.xba
@@ -251,7 +251,7 @@ Sub Load_fr
 	end with
 
 	&apos; dialog choice
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label           = &quot;Nom du lot&quot;
 		.Bt_app.HelpText     = &quot;Ajouter les paramètres à la fin du lot existant&quot;
 		.Bt_app.Label        = &quot;Ajouter&quot;

--- a/Code/AltSearch/Local_it.xba
+++ b/Code/AltSearch/Local_it.xba
@@ -255,7 +255,7 @@ Sub Load_it
 	end with
 
 	&apos; dialog choice
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label       =&quot;Nome del batch&quot;
 		.Bt_app.HelpText =&quot;Aggiungi parametri correnti alla fine del batch esistente&quot;
 		.Bt_app.Label    =&quot;Aggiungi&quot;

--- a/Code/AltSearch/Local_nl.xba
+++ b/Code/AltSearch/Local_nl.xba
@@ -251,7 +251,7 @@ Sub Load_nl
 	end with
 
 	&apos; keuze dialoogvenster
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label       =&quot;Naam van batch&quot;
 		.Bt_app.HelpText =&quot;Huidige parameters toevoegen aan einde van bestaande batch&quot;
 		.Bt_app.Label    =&quot;Toevoegen&quot;

--- a/Code/AltSearch/Local_ru.xba
+++ b/Code/AltSearch/Local_ru.xba
@@ -252,7 +252,7 @@ Sub Load_ru
 	end with
 
 	&apos; dialog choice
-	with oDia.model
+	with oDIA_choice.model
 		.Lb3.Label           = &quot;Имя группы&quot;
 		.Bt_app.HelpText     = &quot;Добавить текущие параметры в конец существующей группы&quot;
 		.Bt_app.Label        = &quot;Добавить&quot;


### PR DESCRIPTION
As mentioned in #95, **oDia** was renamed to **oDIA_choice**, but I got the error for cs localization after I wanted to run AltSearch. In translation it is `Variable of object not set` or similarly. 
<img width="1095" height="755" alt="bug" src="https://github.com/user-attachments/assets/2c027979-c55a-43d4-945c-6060e9d392b6" />

It seems the variable **oDia** in localization modules also need to rename to **oDIA_choice**
