### PR TITLE
Refine Italian help text syncing with English latest modifications

### DIFF
--- a/Code/Help/HelpAltSearch_en.html
+++ b/Code/Help/HelpAltSearch_en.html
@@ -338,7 +338,7 @@
 		<p>When you double-click on an item of the list or click the <var>Execute</var> button, the chosen sequence will be loaded and the search and replace operations will be executed. When using batches on selections, leave 1 or 2 empty paragraphs before and after the selection.</p>
 		<p>The <var>Transfer</var> button is used for transferring the parameters of settings, searching, and replacing to the search dialog box without executing them. If the batch contains a sequence of several searches and replacements, only the last part of this sequence will be transferred.</p>
 
-		<h3><a id="k-shorcut">Keyboard shortcuts</h3>
+		<h3 id="k-shorcut">Keyboard shortcuts</h3>
 		<p>The button <var>Key shortcut</var> opens a dialog box that allows you to assign a keyboard shortcut to an existing batch.</p>
 		<p class="center">
 			<img src="img/altsearch_shortcuts_en.png" width="402" height="328" alt="Keyboard shortcuts">

--- a/Code/Help/HelpAltSearch_it.html
+++ b/Code/Help/HelpAltSearch_it.html
@@ -338,7 +338,7 @@
 		<p>Facendo un doppio clic su un elemento dell’elenco delle procedure batch o quando si fa clic sul pulsante <var>Esegui</var>, la sequenza selezionata viene caricata e vengono eseguite le relative operazioni di ricerca e sostituzione. Quando si usano delle procedure batch su delle selezioni di testo è consigliabile lasciare 1-2 paragrafi vuoti prima e dopo la selezione.</p>
 		<p>Il pulsante <var>Trasferisci</var> viene usato per trasferire i parametri di configurazione, ricerca e sostituzione nella finestra di dialogo, senza che vengano eseguiti. Se però la procedura batch è costituita da una sequenza di numerose ricerche e sostituzioni, verrà trasferita solo l’<i>ultima parte</i> della sequenza.</p>
 
-		<h3><a id="k-shorcut">Scorciatoie da tastiera</h3>
+		<h3 id="k-shorcut">Scorciatoie da tastiera</h3>
 		<p>Facendo clic sul pulsante <var>Scorciatoie</var> presente nella finestra di <b>Gestione batch</b> si apre una finestra di dialogo che consente di assegnare delle scorciatoie da tastiera alle procedure batch esistenti.</p>
 		<p class="center">
 			<img src="img/altsearch_shortcuts_it.png" width="402" height="328" alt="Scorciatoie da tastiera">


### PR DESCRIPTION
Updated text in **HelpAltSearch_it.html** for clarity and consistency, including changes to batch processing descriptions and keyboard shortcuts.

@Bantoniof : I noticed that the the image "altsearch_script_it.png" shows a list of procedures for which I changed many [Name].
So, in order to maintain the consistency with all other images, could you please create a _new_ "**altsearch_script_it.png**" taking a screenshot like that reported below, showing the new list of batches as modified in the **altsearch_script_it.txt**?

TIA
Topoldo

<img width="480" height="348" alt="Senza titolo" src="https://github.com/user-attachments/assets/a351e04b-5b3f-4ef0-a122-50296064ee41" />
